### PR TITLE
No need to say "for YunoHost" in app name (or the description either)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "Shadowsocks for  Yunohost",
+    "name": "Shadowsocks",
     "id": "shadowsocks",
     "packaging_format": 1,
     "description": {


### PR DESCRIPTION
Otherwise the name is long and creates CSS rendering issues in the app catalog